### PR TITLE
chore: typescript 5, make it dev dependency

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,8 +1,8 @@
-declare type HeaderType = {
+type HeaderType = {
     name: string;
     value: string;
 };
-declare type ContentTypeHeader = {
+type ContentTypeHeader = {
     contentType: string;
     boundary?: string;
     additionalCT?: HeaderType;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,35 +1,38 @@
 {
   "name": "mime_message_composer",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mime_message_composer",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "license": "MIT",
-      "dependencies": {
-        "typescript": "^4.5.2"
+      "devDependencies": {
+        "typescript": "^5.0.0"
       }
     },
     "node_modules/typescript": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
-      "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     }
   },
   "dependencies": {
     "typescript": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
-      "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw=="
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "author": "Bipin Maharjan",
   "license": "MIT",
-  "dependencies": {
-    "typescript": "^4.5.2"
+  "devDependencies": {
+    "typescript": "^5.0.0"
   }
 }


### PR DESCRIPTION
- Upgrade typescript to 5,
- Make it also dev dependency, so users don't get it transitively.